### PR TITLE
only match /^#/ to create blastn_refine.txt

### DIFF
--- a/scp/5_blastn_caller.cpp
+++ b/scp/5_blastn_caller.cpp
@@ -35,7 +35,7 @@ int BlastnCaller(string WD_dir, string chr, string t, int L_len, int cus_seq_len
     
     string sys_blastncaller;
     
-    sys_blastncaller = "cat "+WD_dir+"blastn.txt |grep -v \"#\" > "+WD_dir+"blastn_refine.txt";
+    sys_blastncaller = "cat "+WD_dir+"blastn.txt |grep -v \"^#\" > "+WD_dir+"blastn_refine.txt";
     
     
     char *syst_blastncaller = new char[sys_blastncaller.length()+1];


### PR DESCRIPTION
Hi @WeichenZhou, thanks for sharing a great tool! 

Some assemblies created using long reads (like this [one](https://s3-us-west-2.amazonaws.com/human-pangenomics/index.html?prefix=working/HPRC/HG00621/assemblies/year1_f1_assembly_v2_genbank/)) contain “#” in their names. Consequently, all such assemblies would be excluded from blastn_refine.txt.

To address this issue, we can modify the grep command to only match the pattern /^#/, which should work as intended. 

Thanks,

-Xiaoyu Zhuo