### PR TITLE
Remove cap on maximum BLAST results

### DIFF
--- a/scp/4_blastn.cpp
+++ b/scp/4_blastn.cpp
@@ -60,19 +60,19 @@ int blastn(string WD_dir, string t, string direc){
      */
     
     if(t=="LINE"){
-        sys_blastn = "blastn -evalue 0.001 -task blastn -gapopen 4 -query "+direc+"/lib/L1.3.fasta -subject "+WD_dir+"SEQ.masked -outfmt \"7 qacc sacc evalue qstart qend sstart send\" >  "+WD_dir+"blastn.txt";
+        sys_blastn = "blastn -evalue 0.001 -task blastn -gapopen 4 -max_target_seqs 1000000000 -query "+direc+"/lib/L1.3.fasta -subject "+WD_dir+"SEQ.masked -outfmt \"7 qacc sacc evalue qstart qend sstart send\" >  "+WD_dir+"blastn.txt";
     }
     else if(t=="ALU"){
-        sys_blastn = "blastn -evalue 0.001 -task blastn -gapopen 4 -query "+direc+"/lib/AluY.fasta -subject "+WD_dir+"SEQ.masked -outfmt \"7 qacc sacc evalue qstart qend sstart send\" >  "+WD_dir+"blastn.txt";
+        sys_blastn = "blastn -evalue 0.001 -task blastn -gapopen 4 -max_target_seqs 1000000000 -query "+direc+"/lib/AluY.fasta -subject "+WD_dir+"SEQ.masked -outfmt \"7 qacc sacc evalue qstart qend sstart send\" >  "+WD_dir+"blastn.txt";
     }
     else if(t=="SVA"){
-        sys_blastn = "blastn -evalue 0.001 -task blastn -gapopen 4 -query "+direc+"/lib/SVA_F.fasta -subject "+WD_dir+"SEQ.masked -outfmt \"7 qacc sacc evalue qstart qend sstart send\" >  "+WD_dir+"blastn.txt";
+        sys_blastn = "blastn -evalue 0.001 -task blastn -gapopen 4 -max_target_seqs 1000000000 -query "+direc+"/lib/SVA_F.fasta -subject "+WD_dir+"SEQ.masked -outfmt \"7 qacc sacc evalue qstart qend sstart send\" >  "+WD_dir+"blastn.txt";
     }
     else if(t=="HERVK"){
-        sys_blastn = "blastn -evalue 0.001 -task blastn -gapopen 4 -query "+direc+"/lib/HERVK.fasta -subject "+WD_dir+"SEQ.masked -outfmt \"7 qacc sacc evalue qstart qend sstart send\" >  "+WD_dir+"blastn.txt";
+        sys_blastn = "blastn -evalue 0.001 -task blastn -gapopen 4 -max_target_seqs 1000000000 -query "+direc+"/lib/HERVK.fasta -subject "+WD_dir+"SEQ.masked -outfmt \"7 qacc sacc evalue qstart qend sstart send\" >  "+WD_dir+"blastn.txt";
     }
     else {
-        sys_blastn = "blastn -evalue 0.001 -task blastn -gapopen 4 -query "+t+" -subject "+WD_dir+"SEQ.masked -outfmt \"7 qacc sacc evalue qstart qend sstart send\" >  "+WD_dir+"blastn.txt";
+        sys_blastn = "blastn -evalue 0.001 -task blastn -gapopen 4 -max_target_seqs 1000000000 -query "+t+" -subject "+WD_dir+"SEQ.masked -outfmt \"7 qacc sacc evalue qstart qend sstart send\" >  "+WD_dir+"blastn.txt";
     }
     
     char *syst_blastn = new char[sys_blastn.length()+1];

--- a/scp/6_TSD_seq.cpp
+++ b/scp/6_TSD_seq.cpp
@@ -723,7 +723,7 @@ int tsd_module(string WD_dir, string t, int tsd_index){
                     ss1<<e1-s1+1;
                     ss1>>s_len1;
                     //string sys_blastn = "blastn -task blastn -query <( echo -e \">.5723.6043.7572.7860.923022.923022.17.+.0.0.0.0.0.0.0\\nTAAAATATTACTATTAGTGGTGAGAACAACTTAAAAAATCTGGCTTCTATT\\n\";) -subject ( echo -e \">.5723.6043.7572.7860.923022.923022.17.+.0.0.0.0.0.0.0\\nTAAAATATTACTATTAGTGGTGAGAACAACTTAAAAAATCTGGCTTCTATT\\n\";) -word_size 6 -evalue 50 -dust no -outfmt \"7 std\" |grep -v \"#\" | awk '{if($3>=80&&$4>=6&&($10-$9)>0) print \"1\"}' >> "+WD_dir+"TSD_blastn_pre.txt ";
-                    string sys_blastn = "bash -c \"blastn -task blastn -query <(printf "+(fasta5_str)+") -subject <(printf "+(fasta3_str)+") -word_size 6 -evalue 50 -dust no -gapopen 6 -penalty -4 -outfmt \\\"7 std\\\" |grep -v \\\"#\\\" | awk '{if(\\\$3>=80&&\\\$4>=6&&(\\\$10-\\\$9)>0) print \\\""+name[i]+seq_index+"\\\","+(s_len)+"+\\\$7,"+(s_len)+"+\\\$8,\\\$9,\\\$10,"+s_len1+",\\\""+s_le_3+"\\\"}' >> "+WD_dir+"TSD_blastn_pre.txt \"";
+                    string sys_blastn = "bash -c \"blastn -task blastn -max_target_seqs 1000000000 -query <(printf "+(fasta5_str)+") -subject <(printf "+(fasta3_str)+") -word_size 6 -evalue 50 -dust no -gapopen 6 -penalty -4 -outfmt \\\"7 std\\\" |grep -v \\\"#\\\" | awk '{if(\\\$3>=80&&\\\$4>=6&&(\\\$10-\\\$9)>0) print \\\""+name[i]+seq_index+"\\\","+(s_len)+"+\\\$7,"+(s_len)+"+\\\$8,\\\$9,\\\$10,"+s_len1+",\\\""+s_le_3+"\\\"}' >> "+WD_dir+"TSD_blastn_pre.txt \"";
                     
                     //cout<<sys_blastn <<endl;
                     char *syst_blastn = new char[sys_blastn.length()+1];
@@ -736,7 +736,7 @@ int tsd_module(string WD_dir, string t, int tsd_index){
                     ss1<<e_3_1-s_3_1+1;
                     ss1>>s_len1;
                     //string sys_blastn = "blastn -task blastn -query <(echo -e \">"+seq_index+"'\\n'"+fasta5_str+"\") -subject <(echo -e \">"+seq_index+"'\\n'"+fasta3_str+"\")";
-                    string sys_blastn = "bash -c \"blastn -task blastn -query <(printf "+(fasta5_str)+") -subject <(printf "+(fasta3_str)+") -word_size 6 -evalue 50 -dust no  -gapopen 6 -penalty -4 -outfmt \\\"7 std\\\" |grep -v \\\"#\\\" | awk '{if(\\\$3>=80&&\\\$4>=6&&(\\\$10-\\\$9)>0) print \\\""+name[i]+seq_index+"\\\",\\\$7,\\\$8,"+(s_len)+"+\\\$9,"+(s_len)+"+\\\$10,\\\""+s_le_5+"\\\","+s_len1+"}'  >> "+WD_dir+"TSD_blastn_pre.txt \"";
+                    string sys_blastn = "bash -c \"blastn -task blastn -max_target_seqs 1000000000 -query <(printf "+(fasta5_str)+") -subject <(printf "+(fasta3_str)+") -word_size 6 -evalue 50 -dust no  -gapopen 6 -penalty -4 -outfmt \\\"7 std\\\" |grep -v \\\"#\\\" | awk '{if(\\\$3>=80&&\\\$4>=6&&(\\\$10-\\\$9)>0) print \\\""+name[i]+seq_index+"\\\",\\\$7,\\\$8,"+(s_len)+"+\\\$9,"+(s_len)+"+\\\$10,\\\""+s_le_5+"\\\","+s_len1+"}'  >> "+WD_dir+"TSD_blastn_pre.txt \"";
                     
                     //cout<<sys_blastn <<endl;
                     char *syst_blastn = new char[sys_blastn.length()+1];

--- a/scp/7_FP_ex.cpp
+++ b/scp/7_FP_ex.cpp
@@ -471,7 +471,7 @@ int fp_ex(string WD_dir, string fasta, string chr, string t, int tsd_index){
                     string fasta5_str_length=to_string(fasta5_str_len);
                     string fasta3_str_length=to_string(fasta3_str_len);
                     
-                    string sys_3_blast = "bash -c \"blastn -evalue 0.05 -task blastn -query <(printf "+(fasta5_str)+") -subject "+ref_junc_file+" -dust no -outfmt \\\"7 std\\\" |grep -v \\\"#\\\" | awk '{if(\\\$3>=80&&\\\$4>="+fasta5_str_length+"&&(\\\$10-\\\$9)>0) print \\\"1\\\"}' |wc -l \"";
+                    string sys_3_blast = "bash -c \"blastn -evalue 0.05 -task blastn -max_target_seqs 1000000000 -query <(printf "+(fasta5_str)+") -subject "+ref_junc_file+" -dust no -outfmt \\\"7 std\\\" |grep -v \\\"#\\\" | awk '{if(\\\$3>=80&&\\\$4>="+fasta5_str_length+"&&(\\\$10-\\\$9)>0) print \\\"1\\\"}' |wc -l \"";
                     //> "+WD_dir+"read_result_junc_fake.txt";
                     //cout<<sys_3_blast<<endl;
                     
@@ -493,7 +493,7 @@ int fp_ex(string WD_dir, string fasta, string chr, string t, int tsd_index){
                     //loc_tsd_fp[w][0]=pp_3_int;
                     loc_tsd_fp[w][0]=accumulate(pp_3_int.begin(),pp_3_int.end(),loc_tsd_fp[w][0]);
                     
-                    string sys_3_blast_2 = "bash -c \"blastn -evalue 0.05 -task blastn -query <(printf "+(fasta3_str)+") -subject "+ref_junc_file+" -dust no -outfmt \\\"7 std\\\" |grep -v \\\"#\\\" | awk '{if(\\\$3>=80&&\\\$4>="+fasta3_str_length+"&&(\\\$10-\\\$9)>0) print \\\"1\\\"}' |wc -l \"";
+                    string sys_3_blast_2 = "bash -c \"blastn -evalue 0.05 -task blastn -max_target_seqs 1000000000 -query <(printf "+(fasta3_str)+") -subject "+ref_junc_file+" -dust no -outfmt \\\"7 std\\\" |grep -v \\\"#\\\" | awk '{if(\\\$3>=80&&\\\$4>="+fasta3_str_length+"&&(\\\$10-\\\$9)>0) print \\\"1\\\"}' |wc -l \"";
                     //> "+WD_dir+"read_result_junc_fake.txt";
                     //cout<<sys_3_blast_2<<endl;
                     


### PR DESCRIPTION
The first stage of PALMER bins reads into 1 megabase regions and uses BLAST to compare all the (masked) reads in a region against a consensus sequence (e.g. the L1 consesus sequence) to identify reads with signal.

`blastn`'s `-max_target_seqs` command-line option is used to limit the number of results returned.  Unfortunately this option has a default value of `500` and PALMER doesn't override that, which means that at most 500 reads can be reported from any given megabase bin.  This is problematic when analyzing larger data sets, e.g. some of our targeted capture data sets have 2000+x coverage at a single locus.

This patch overrides the default 500 limit to 1 billion, which should be plenty for the forseeable future (as far as I can tell there's no way to tell BLAST to have no limit, unfortunately).
