### PR TITLE
Incorporate reference read evidence into genotype likelihoods

### DIFF
--- a/PALMER.cpp
+++ b/PALMER.cpp
@@ -400,12 +400,10 @@ string genotype_calls(const string &calls_path, const string &bam_path, int mapq
         }
 
         double alt_reads = idx < normalized.size() ? observations[idx] : 0.0;
-        double total_reads = alt_reads;
-        if (coverage_est > 0.0 && isfinite(coverage_est)) {
-            total_reads = coverage_est;
-        }
+        bool has_coverage = coverage_est > 0.0 && isfinite(coverage_est);
+        double total_reads = has_coverage ? coverage_est : 0.0;
 
-        if (total_reads < alt_reads) {
+        if (has_coverage && total_reads < alt_reads) {
             total_reads = alt_reads;
         }
 


### PR DESCRIPTION
## Summary
- compute genotype likelihoods using alt and reference read counts to favor allele fractions near 0/0, 0/1, and 1/1
- retain a mixture-based fallback when coverage information is unavailable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692149147fb4833299a24a7ff576ed38)