### PR TITLE
Refactor shared headers for scp pipeline

### DIFF
--- a/scp/1_samtools.cpp
+++ b/scp/1_samtools.cpp
@@ -1,19 +1,5 @@
 ////copyright by ArthurZhou @ UMich&Fudan&HUST
-#include <stdlib.h>
-#include <iostream>
-#include <string>
-#include <string.h>
-#include <fstream>
-#include <vector>
-#include <cmath>
-#include <cstdlib>
-#include <sstream>
-#include <algorithm>
-#include <functional>
-#include <iomanip>
-#include <cstdlib>
-
-using namespace std;
+#include "common.hpp"
 
 int samtools(string working_dir, string input_bam, string chr, string start, string end, string fasta, string MAPQ){
 

--- a/scp/3_read_masker.cpp
+++ b/scp/3_read_masker.cpp
@@ -1,19 +1,5 @@
 ////copyright by ArthurZhou @ UMich&Fudan&HUST
-#include <stdlib.h>
-#include <iostream>
-#include <string>
-#include <string.h>
-#include <fstream>
-#include <vector>
-#include <cmath>
-#include <cstdlib>
-#include <sstream>
-#include <algorithm>
-#include <functional>
-#include <iomanip>
-#include <cstdlib>
-
-using namespace std;
+#include "common.hpp"
 
 int ReadMasker(string WD_dir, string mode){
     

--- a/scp/4_blastn.cpp
+++ b/scp/4_blastn.cpp
@@ -1,19 +1,5 @@
 //copyright by ArthurZhou @ UMich&Fudan&HUST
-#include <stdlib.h>
-#include <iostream>
-#include <string>
-#include <string.h>
-#include <fstream>
-#include <vector>
-#include <cmath>
-#include <cstdlib>
-#include <sstream>
-#include <algorithm>
-#include <functional>
-#include <iomanip>
-#include <cstdlib>
-
-using namespace std;
+#include "common.hpp"
 
 int blastn(string WD_dir, string t, string direc){
     

--- a/scp/5_blastn_caller.cpp
+++ b/scp/5_blastn_caller.cpp
@@ -1,19 +1,5 @@
 ////copyright by ArthurZhou @ UMich&Fudan&HUST
-#include <stdlib.h>
-#include <iostream>
-#include <string>
-#include <string.h>
-#include <fstream>
-#include <vector>
-#include <cmath>
-#include <cstdlib>
-#include <sstream>
-#include <algorithm>
-#include <functional>
-#include <iomanip>
-#include <cstdlib>
-
-using namespace std;
+#include "common.hpp"
 
 int BlastnCaller(string WD_dir, string chr, string t, int L_len, int cus_seq_len){
         

--- a/scp/6_TSD_seq.cpp
+++ b/scp/6_TSD_seq.cpp
@@ -1,21 +1,5 @@
 //copyright by ArthurZhou @ UMich&Fudan&HUST
-#include <stdlib.h>
-#include <iostream>
-#include <string>
-#include <string.h>
-#include <fstream>
-#include <vector>
-#include <cmath>
-#include <cstdlib>
-#include <sstream>
-#include <algorithm>
-#include <functional>
-#include <iomanip>
-#include <cstdlib>
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-using namespace std;
+#include "common.hpp"
 
 int tsd_module(string WD_dir, string t, int tsd_index){
     

--- a/scp/7_FP_ex.cpp
+++ b/scp/7_FP_ex.cpp
@@ -1,22 +1,5 @@
 //copyright by ArthurZhou @ UMich&Fudan&HUST
-#include <stdlib.h>
-#include <iostream>
-#include <string>
-#include <string.h>
-#include <fstream>
-#include <vector>
-#include <cmath>
-#include <cstdlib>
-#include <sstream>
-#include <algorithm>
-#include <functional>
-#include <iomanip>
-#include <cstdlib>
-#include <numeric>
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-using namespace std;
+#include "common.hpp"
 
 int fp_ex(string WD_dir, string fasta, string chr, string t, int tsd_index){
     

--- a/scp/8_calling.cpp
+++ b/scp/8_calling.cpp
@@ -1,19 +1,5 @@
 //copyright by ArthurZhou @ UMich&Fudan&HUST
-#include <stdlib.h>
-#include <iostream>
-#include <string>
-#include <string.h>
-#include <fstream>
-#include <vector>
-#include <cmath>
-#include <cstdlib>
-#include <sstream>
-#include <algorithm>
-#include <functional>
-#include <iomanip>
-#include <cstdlib>
-
-using namespace std;
+#include "common.hpp"
 
 int calling(string WD_dir, string t, int tsd_index){
     

--- a/scp/common.hpp
+++ b/scp/common.hpp
@@ -1,0 +1,23 @@
+// Shared includes for PALMER pipeline components.
+#ifndef PALMER_SCP_COMMON_HPP
+#define PALMER_SCP_COMMON_HPP
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+using namespace std;
+
+#endif // PALMER_SCP_COMMON_HPP

--- a/scp/tube.cpp
+++ b/scp/tube.cpp
@@ -1,21 +1,5 @@
 //copyright by ArthurZhou @ UMich&Fudan&HUST
-#include <stdlib.h>
-#include <iostream>
-#include <string>
-#include <string.h>
-#include <fstream>
-#include <vector>
-#include <cmath>
-#include <cstdlib>
-#include <sstream>
-#include <algorithm>
-#include <functional>
-#include <iomanip>
-#include <cstdlib>
-
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/wait.h>
+#include "common.hpp"
 #include "1_samtools.cpp"
 //#include "2_rm_selector.cpp"
 #include "3_read_masker.cpp"
@@ -24,7 +8,6 @@
 #include "6_TSD_seq.cpp"
 #include "7_FP_ex.cpp"
 #include "8_calling.cpp"
-using namespace std;
 
 int tube(string working_dir, string input_bam, string chr, int start, int end, string type, int ref_n, string direc, string ref_fa, int tsd, int L_len, int cus_seq_len, string mode, int mapq, int intermediate){
     


### PR DESCRIPTION
## Summary
- add a shared `common.hpp` header for scp pipeline components to centralize common includes
- update all scp modules to use the new header to eliminate redundant include lists

## Testing
- make -B


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924b79a638083328c8c35992b16ff71)