### PR TITLE
Handle empty masked reads before blastn

### DIFF
--- a/scp/4_blastn.cpp
+++ b/scp/4_blastn.cpp
@@ -56,6 +56,11 @@ int blastn(string WD_dir, string t, string direc){
         //exit(1);
         return 0;
     }
+
+    if (file1.peek() == ifstream::traits_type::eof()) {
+        cout << "Skipping blastn: masked read file '" << sys_blast << "' is empty; no reads available for BLAST alignment." << endl;
+        return 0;
+    }
     string query;
     if(t=="LINE"){
         query = direc+"/lib/L1.3.fasta";


### PR DESCRIPTION
## Summary
- Add a guard to skip blastn when the masked reads file is empty
- Provide a clearer log message to avoid BLAST errors when no reads are available

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927aff21aa8833283f2dc53e18a1e97)