### PR TITLE
Handle empty blastn output when no reads

### DIFF
--- a/scp/4_blastn.cpp
+++ b/scp/4_blastn.cpp
@@ -57,7 +57,14 @@ int blastn(string WD_dir, string t, string direc){
         return 0;
     }
 
+    string output_file = WD_dir+"blastn_refine.txt";
+
     if (file1.peek() == ifstream::traits_type::eof()) {
+        ofstream empty_output(output_file, ios::trunc);
+        if (!empty_output.is_open()) {
+            cout << "CANNOT CREATE FILE, 'blastn_refine.txt'" << endl;
+            return 0;
+        }
         cout << "Skipping blastn: masked read file '" << sys_blast << "' is empty; no reads available for BLAST alignment." << endl;
         return 0;
     }
@@ -93,8 +100,6 @@ int blastn(string WD_dir, string t, string direc){
         args.emplace_back("-perc_identity");
         args.emplace_back("90");
     }
-
-    string output_file = WD_dir+"blastn_refine.txt";
 
     if (RunBlastn(args, output_file) != 0) {
         return 0;


### PR DESCRIPTION
## Summary
- create an empty blastn_refine.txt when SEQ.masked has no reads
- avoid pipeline failures caused by missing blastn output in no-read scenarios

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927ccd27dbc83329e9af074de70dd50)