### PR TITLE
Fix makefile recipe indentation and targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,15 +1,15 @@
-TARGET = PALMER
-CPP_FILES = $(shell ls *.cpp)
-HTS_CFLAGS = $(shell pkg-config --cflags htslib 2>/dev/null)
-HTS_LIBS = $(shell pkg-config --libs htslib 2>/dev/null)
+TARGET := PALMER
+SRC := $(TARGET).cpp
+HTS_CFLAGS := $(shell pkg-config --cflags htslib 2>/dev/null)
+HTS_LIBS := $(shell pkg-config --libs htslib 2>/dev/null)
 HTS_LIBS ?= -lhts
 
 ifeq ($(strip $(HTS_CFLAGS)),)
 $(error "htslib headers not found. Please install htslib and ensure pkg-config can locate it (see README.md).")
 endif
 
-$(TARGET): $(OBJS)
-        g++ -o $(TARGET) $(HTS_CFLAGS) $(BASE).cpp -O3 -w -std=c++17 -pthread -lstdc++fs $(HTS_LIBS)
+$(TARGET): $(SRC)
+	g++ -o $@ $(HTS_CFLAGS) $(CXXFLAGS) $< -O3 -w -std=c++17 -pthread -lstdc++fs $(HTS_LIBS)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
## Summary
- fix makefile recipe indentation by using tabs for commands
- simplify build target to compile PALMER.cpp directly and ensure variable defaults

## Testing
- not run (htslib dependency not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69289f81cf20833292b848d8867aa1fe)