### PR TITLE
Fix blastn outfmt argument quoting

### DIFF
--- a/scp/7_FP_ex.cpp
+++ b/scp/7_FP_ex.cpp
@@ -64,11 +64,13 @@ string fetch_region_sequence(faidx_t *fai, const string &region) {
 }
 
 int count_blast_hits(const std::string &query_path, const std::string &subject_path, int min_length) {
-    const std::string command =
-        "BLAST_USAGE_REPORT=0 blastn -evalue 0.05 -task blastn -query " + query_path +
-        " -subject " + subject_path + " -dust no -outfmt 7 std";
+    std::ostringstream command;
+    command << "BLAST_USAGE_REPORT=0 blastn -evalue 0.05 -task blastn"
+            << " -query \"" << query_path << "\""
+            << " -subject \"" << subject_path << "\""
+            << " -dust no -outfmt '7 std'";
 
-    FILE *pp = popen(command.c_str(), "r");
+    FILE *pp = popen(command.str().c_str(), "r");
     if (!pp) {
         return -1;
     }


### PR DESCRIPTION
## Summary
- properly quote blastn query and subject paths
- wrap outfmt value to prevent it being treated as positional arguments

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928a2725b148332bc1c6fe420d806c6)