### PR TITLE
Add total potential supporting read counts

### DIFF
--- a/PALMER.cpp
+++ b/PALMER.cpp
@@ -942,7 +942,9 @@ void write_vcf_output(const string &calls_path, const string &tsd_path, const st
     vcf_stream << "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End coordinate of the insertion interval\">" << endl;
     vcf_stream << "##INFO=<ID=SUBTYPE,Number=1,Type=String,Description=\"Insertion subtype (matches --type)\">" << endl;
     vcf_stream << "##INFO=<ID=CS,Number=1,Type=Integer,Description=\"Confident supporting reads\">" << endl;
-    vcf_stream << "##INFO=<ID=PS,Number=1,Type=Integer,Description=\"Potential supporting reads\">" << endl;
+    vcf_stream << "##INFO=<ID=PS,Number=1,Type=Integer,Description=\"Total potential supporting reads\">" << endl;
+    vcf_stream << "##INFO=<ID=PS5,Number=1,Type=Integer,Description=\"Potential supporting reads from the insertion 5' end\">" << endl;
+    vcf_stream << "##INFO=<ID=PS3,Number=1,Type=Integer,Description=\"Potential supporting reads from the insertion 3' end\">" << endl;
     vcf_stream << "##INFO=<ID=SEG,Number=1,Type=Integer,Description=\"Potential segmental supporting reads\">" << endl;
     vcf_stream << "##INFO=<ID=ORIENTATION,Number=1,Type=String,Description=\"Insertion orientation\">" << endl;
     vcf_stream << "##INFO=<ID=POLYA,Number=1,Type=Integer,Description=\"polyA tail size\">" << endl;
@@ -985,7 +987,7 @@ void write_vcf_output(const string &calls_path, const string &tsd_path, const st
             fields.push_back(field);
         }
 
-        if (fields.size() < 21) {
+        if (fields.size() < 23) {
             continue;
         }
 
@@ -1010,16 +1012,18 @@ void write_vcf_output(const string &calls_path, const string &tsd_path, const st
         info_prefix += ";SUBTYPE=" + (ins_type.empty() ? string("NA") : ins_type);
         info_prefix += ";END=" + end;
         info_prefix += ";CS=" + fields[10];
-        info_prefix += ";PS=" + fields[11];
-        info_prefix += ";SEG=" + fields[12];
-        info_prefix += ";ORIENTATION=" + fields[13];
-        info_prefix += ";POLYA=" + fields[14];
-        info_prefix += ";TSD5=" + fields[15];
-        info_prefix += ";TSD3=" + fields[16];
-        info_prefix += ";TRANSD=" + fields[17];
-        info_prefix += ";INV5=" + fields[18];
-        info_prefix += ";INV5_END=" + fields[19];
-        info_prefix += ";INV5_START=" + fields[20];
+        info_prefix += ";PS=" + fields[13];
+        info_prefix += ";PS5=" + fields[11];
+        info_prefix += ";PS3=" + fields[12];
+        info_prefix += ";SEG=" + fields[14];
+        info_prefix += ";ORIENTATION=" + fields[15];
+        info_prefix += ";POLYA=" + fields[16];
+        info_prefix += ";TSD5=" + fields[17];
+        info_prefix += ";TSD3=" + fields[18];
+        info_prefix += ";TRANSD=" + fields[19];
+        info_prefix += ";INV5=" + fields[20];
+        info_prefix += ";INV5_END=" + fields[21];
+        info_prefix += ";INV5_START=" + fields[22];
         info_prefix += ";START_INVAR=" + to_string(start_invariant);
         info_prefix += ";END_INVAR=" + to_string(end_invariant);
 
@@ -1037,7 +1041,7 @@ void write_vcf_output(const string &calls_path, const string &tsd_path, const st
         }
 
         string key;
-        size_t key_fields = min(fields.size(), static_cast<size_t>(21));
+        size_t key_fields = min(fields.size(), static_cast<size_t>(23));
         for (size_t i = 1; i < key_fields; ++i) {
             if (i > 1) key += "|";
             key += fields[i];
@@ -1983,7 +1987,7 @@ int main(int argc, char *argv[]){
     ofstream file3;
     file3.open(syst_final_title,ios::trunc);
     
-    file3<<"cluster_id"<<'\t'<<"chr"<<'\t'<<"start1"<<'\t'<<"start2"<<'\t'<<"end1"<<'\t'<<"end2"<<'\t'<<"start1_inVariant"<<'\t'<<"start2_inVariant"<<'\t'<<"end1_inVariant"<<'\t'<<"end2_inVariant"<<'\t'<<"Confident_supporting_reads"<<'\t'<<"Potential_supporting_reads"<<'\t'<<"Ptential_segmental_supporting_reads"<<'\t'<<"orientation"<<'\t'<<"polyA-tail_size"<<'\t'<<"5'_TSD_size"<<'\t'<<"3'_TSD_size"<<'\t'<<"Predicted_transD_size"<<'\t'<<"Has_5'_inverted_sequence?"<<'\t'<<"5'_inverted_seq_end"<<'\t'<<"5'_seq_start"<<endl;
+    file3<<"cluster_id"<<'\t'<<"chr"<<'\t'<<"start1"<<'\t'<<"start2"<<'\t'<<"end1"<<'\t'<<"end2"<<'\t'<<"start1_inVariant"<<'\t'<<"start2_inVariant"<<'\t'<<"end1_inVariant"<<'\t'<<"end2_inVariant"<<'\t'<<"Confident_supporting_reads"<<'\t'<<"Potential_supporting_reads_from_5'_end"<<'\t'<<"Potential_supporting_reads_from_3'_end"<<'\t'<<"Total_potential_supporting_reads"<<'\t'<<"Ptential_segmental_supporting_reads"<<'\t'<<"orientation"<<'\t'<<"polyA-tail_size"<<'\t'<<"5'_TSD_size"<<'\t'<<"3'_TSD_size"<<'\t'<<"Predicted_transD_size"<<'\t'<<"Has_5'_inverted_sequence?"<<'\t'<<"5'_inverted_seq_end"<<'\t'<<"5'_seq_start"<<endl;
     
     string sys_final_tsd_title = WD+output+"_TSD_reads.txt";
     char *syst_final_tsd_title = new char[sys_final_tsd_title.length()+1];

--- a/example/sample_calls.txt
+++ b/example/sample_calls.txt
@@ -1,4 +1,4 @@
-cluster_id	chr start1	start2	end1	end2	start1_inVariant	start2_inVariant	end1_inVariant	end2_inVariant	Confident_supporting_reads	Potential_supporting_reads	Ptential_segmental_supporting_reads	orientation	polyA-tail_size	5'_TSD_size	3'_TSD_size	Predicted_transD_size	Has_5'_inverted_sequence?	5'_inverted_seq_end	5'_seq_start
+cluster_id	chr	start1	start2	end1	end2	start1_inVariant	start2_inVariant	end1_inVariant	end2_inVariant	Confident_supporting_reads	Potential_supporting_reads_from_5'_end	Potential_supporting_reads_from_3'_end	Total_potential_supporting_reads	Ptential_segmental_supporting_reads	orientation	polyA-tail_size	5'_TSD_size	3'_TSD_size	Predicted_transD_size	Has_5'_inverted_sequence?	5'_inverted_seq_end	5'_seq_start
 cluster0_chr19_4912583_4912583_4912583_4912583	chr19	4912583	4912583	4912583	4912583	3698	3698	6032	6032	0	1	0	-	-	0	0	0	1	3749	4681
 cluster1_chr19_4777212_4777212_4777212_4777212	chr19	4777212	4777212	4777212	4777212	5241	5241	6046	6046	0	1	0	-	-	0	0	0	1	5717	5727
 cluster2_chr19_4974781_4974781_4974781_4974781	chr19	4974781	4974781	4974781	4974781	5350	5350	6033	6033	0	1	0	+	-	0	0	0	1	5599	5725

--- a/scp/8_calling.cpp
+++ b/scp/8_calling.cpp
@@ -254,6 +254,8 @@ int calling(string WD_dir, string t, int tsd_index){
             int number=0;
             int number_true=0;
             int number_all=1;
+            int number_all_5=1;
+            int number_all_3=1;
             loc[i][6]=-1;
             int flag=1;
             
@@ -363,6 +365,8 @@ int calling(string WD_dir, string t, int tsd_index){
                                 flag=1;
                                 loc[j][6]=-1;
                                 number_all=number_all+1;
+                                number_all_5=number_all_5+1;
+                                number_all_3=number_all_3+1;
                                 
                                 string loc_0, loc_1, loc_2, loc_3, loc_4, loc_5;
                                 stringstream ss_0;
@@ -447,6 +451,7 @@ int calling(string WD_dir, string t, int tsd_index){
                                     flag=1;
                                     loc[j][6]=-1;
                                     number_all=number_all+1;
+                                    number_all_5=number_all_5+1;
                                     
                                     string loc_0, loc_1, loc_2, loc_3, loc_4, loc_5;
                                     stringstream ss_0;
@@ -528,6 +533,7 @@ int calling(string WD_dir, string t, int tsd_index){
                                     flag=1;
                                     loc[j][6]=-1;
                                     number_all=number_all+1;
+                                    number_all_5=number_all_5+1;
                                     
                                     string loc_0, loc_1, loc_2, loc_3, loc_4, loc_5;
                                     stringstream ss_0;
@@ -613,6 +619,7 @@ int calling(string WD_dir, string t, int tsd_index){
                                     flag=1;
                                     loc[j][6]=-1;
                                     number_all=number_all+1;
+                                    number_all_3=number_all_3+1;
                                     
                                     string loc_0, loc_1, loc_2, loc_3, loc_4, loc_5;
                                     stringstream ss_0;
@@ -694,6 +701,7 @@ int calling(string WD_dir, string t, int tsd_index){
                                     flag=1;
                                     loc[j][6]=-1;
                                     number_all=number_all+1;
+                                    number_all_3=number_all_3+1;
                                     
                                     string loc_0, loc_1, loc_2, loc_3, loc_4, loc_5;
                                     stringstream ss_0;
@@ -1059,7 +1067,15 @@ int calling(string WD_dir, string t, int tsd_index){
             //transD ployA
             int flag_ployA=0;
             int flag_trans=1;
-            
+
+            int supporting_reads_from_5_end = number_all_5;
+            int supporting_reads_from_3_end = number_all_3;
+            if (orien[i] == "-") {
+                supporting_reads_from_5_end = number_all_3;
+                supporting_reads_from_3_end = number_all_5;
+            }
+            int total_potential_supporting_reads = number_all;
+
             for(;flag_ployA==0&&flag_trans==1;){
                 
                 //best subreads cluster candidate
@@ -1075,7 +1091,7 @@ int calling(string WD_dir, string t, int tsd_index){
                 //cout<<"p="<<p<<endl;
                 if(p==0){
                     
-                    file2<<"cluster"<<i<<"_"<<info[i][1]<<"_"<<start1+S<<"_"<<start2-S<<"_"<<end1+S<<"_"<<end2-S<<'\t'<<info[i][1]<<'\t'<<start1+S<<'\t'<<start2-S<<'\t'<<end1+S<<'\t'<<end2-S<<'\t'<<L1_s1+L<<'\t'<<L1_s2-L<<'\t'<<L1_e1+L<<'\t'<<L1_e2-L<<'\t'<<"0"<<'\t'<<number_all<<'\t'<<(number_all-number)<<'\t'<<orien[i]<<'\t'<<"-"<<'\t'<<"0"<<'\t'<<"0"<<'\t'<<"0"<<'\t'<<loc_TP[i][0]<<'\t'<<int((L1_s_TP1+L1_s_TP2)/2)<<'\t'<<int((L1_e_TP1+L1_e_TP2)/2)<<endl;
+                    file2<<"cluster"<<i<<"_"<<info[i][1]<<"_"<<start1+S<<"_"<<start2-S<<"_"<<end1+S<<"_"<<end2-S<<'\t'<<info[i][1]<<'\t'<<start1+S<<'\t'<<start2-S<<'\t'<<end1+S<<'\t'<<end2-S<<'\t'<<L1_s1+L<<'\t'<<L1_s2-L<<'\t'<<L1_e1+L<<'\t'<<L1_e2-L<<'\t'<<"0"<<'\t'<<supporting_reads_from_5_end<<'\t'<<supporting_reads_from_3_end<<'\t'<<total_potential_supporting_reads<<'\t'<<(number_all-number)<<'\t'<<orien[i]<<'\t'<<"-"<<'\t'<<"0"<<'\t'<<"0"<<'\t'<<"0"<<'\t'<<loc_TP[i][0]<<'\t'<<int((L1_s_TP1+L1_s_TP2)/2)<<'\t'<<int((L1_e_TP1+L1_e_TP2)/2)<<endl;
                     file4<<"cluster"<<i<<"_"<<info[i][1]<<"_"<<start1+S<<"_"<<start2-S<<"_"<<end1+S<<"_"<<end2-S<<'\t'<<seq_index_a<<'\t'<<"N"<<'\t'<<"N"<<'\t'<<"N"<<'\t'<<"N"<<'\t'<<info_line[i][2]<<endl;
                     
                     
@@ -1443,11 +1459,11 @@ int calling(string WD_dir, string t, int tsd_index){
                     
                     //cluster output
                     if(pa_len<0){
-                        file2<<"cluster"<<i<<"_"<<info[i][1]<<"_"<<start1+S<<"_"<<start2-S<<"_"<<end1+S<<"_"<<end2-S<<'\t'<<info[i][1]<<'\t'<<start1+S<<'\t'<<start2-S<<'\t'<<end1+S<<'\t'<<end2-S<<'\t'<<L1_s1+L<<'\t'<<L1_s2-L<<'\t'<<L1_e1+L<<'\t'<<L1_e2-L<<'\t'<<p<<'\t'<<number_all<<'\t'<<(number_all-number)<<'\t'<<orien[i]<<'\t'<<"-"<<'\t'<<l_len<<'\t'<<r_len<<'\t'<<trans_len<<'\t'<<loc_TP[i][0]<<'\t'<<int((L1_s_TP1+L1_s_TP2)/2)<<'\t'<<int((L1_e_TP1+L1_e_TP2)/2)<<endl;
+                        file2<<"cluster"<<i<<"_"<<info[i][1]<<"_"<<start1+S<<"_"<<start2-S<<"_"<<end1+S<<"_"<<end2-S<<'\t'<<info[i][1]<<'\t'<<start1+S<<'\t'<<start2-S<<'\t'<<end1+S<<'\t'<<end2-S<<'\t'<<L1_s1+L<<'\t'<<L1_s2-L<<'\t'<<L1_e1+L<<'\t'<<L1_e2-L<<'\t'<<p<<'\t'<<supporting_reads_from_5_end<<'\t'<<supporting_reads_from_3_end<<'\t'<<total_potential_supporting_reads<<'\t'<<(number_all-number)<<'\t'<<orien[i]<<'\t'<<"-"<<'\t'<<l_len<<'\t'<<r_len<<'\t'<<trans_len<<'\t'<<loc_TP[i][0]<<'\t'<<int((L1_s_TP1+L1_s_TP2)/2)<<'\t'<<int((L1_e_TP1+L1_e_TP2)/2)<<endl;
                         
                     }
                     else {
-                        file2<<"cluster"<<i<<"_"<<info[i][1]<<"_"<<start1+S<<"_"<<start2-S<<"_"<<end1+S<<"_"<<end2-S<<'\t'<<info[i][1]<<'\t'<<start1+S<<'\t'<<start2-S<<'\t'<<end1+S<<'\t'<<end2-S<<'\t'<<L1_s1+L<<'\t'<<L1_s2-L<<'\t'<<L1_e1+L<<'\t'<<L1_e2-L<<'\t'<<p<<'\t'<<number_all<<'\t'<<(number_all-number)<<'\t'<<orien[i]<<'\t'<<pa_len<<'\t'<<l_len<<'\t'<<r_len<<'\t'<<trans_len<<'\t'<<loc_TP[i][0]<<'\t'<<int((L1_s_TP1+L1_s_TP2)/2)<<'\t'<<int((L1_e_TP1+L1_e_TP2)/2)<<endl;
+                        file2<<"cluster"<<i<<"_"<<info[i][1]<<"_"<<start1+S<<"_"<<start2-S<<"_"<<end1+S<<"_"<<end2-S<<'\t'<<info[i][1]<<'\t'<<start1+S<<'\t'<<start2-S<<'\t'<<end1+S<<'\t'<<end2-S<<'\t'<<L1_s1+L<<'\t'<<L1_s2-L<<'\t'<<L1_e1+L<<'\t'<<L1_e2-L<<'\t'<<p<<'\t'<<supporting_reads_from_5_end<<'\t'<<supporting_reads_from_3_end<<'\t'<<total_potential_supporting_reads<<'\t'<<(number_all-number)<<'\t'<<orien[i]<<'\t'<<pa_len<<'\t'<<l_len<<'\t'<<r_len<<'\t'<<trans_len<<'\t'<<loc_TP[i][0]<<'\t'<<int((L1_s_TP1+L1_s_TP2)/2)<<'\t'<<int((L1_e_TP1+L1_e_TP2)/2)<<endl;
                     }
                     
                     //return
@@ -1851,11 +1867,11 @@ int calling(string WD_dir, string t, int tsd_index){
                     
                     //cluster output
                     if(pa_len<0){
-                        file2<<"cluster"<<i<<"_"<<info[i][1]<<"_"<<start1+S<<"_"<<start2-S<<"_"<<end1+S<<"_"<<end2-S<<'\t'<<info[i][1]<<'\t'<<start1+S<<'\t'<<start2-S<<'\t'<<end1+S<<'\t'<<end2-S<<'\t'<<L1_s1+L<<'\t'<<L1_s2-L<<'\t'<<L1_e1+L<<'\t'<<L1_e2-L<<'\t'<<p<<'\t'<<number_all<<'\t'<<(number_all-number)<<'\t'<<orien[i]<<'\t'<<"-"<<'\t'<<l_len<<'\t'<<r_len<<'\t'<<trans_len<<'\t'<<loc_TP[i][0]<<'\t'<<int((L1_s_TP1+L1_s_TP2)/2)<<'\t'<<int((L1_e_TP1+L1_e_TP2)/2)<<endl;
+                        file2<<"cluster"<<i<<"_"<<info[i][1]<<"_"<<start1+S<<"_"<<start2-S<<"_"<<end1+S<<"_"<<end2-S<<'\t'<<info[i][1]<<'\t'<<start1+S<<'\t'<<start2-S<<'\t'<<end1+S<<'\t'<<end2-S<<'\t'<<L1_s1+L<<'\t'<<L1_s2-L<<'\t'<<L1_e1+L<<'\t'<<L1_e2-L<<'\t'<<p<<'\t'<<supporting_reads_from_5_end<<'\t'<<supporting_reads_from_3_end<<'\t'<<total_potential_supporting_reads<<'\t'<<(number_all-number)<<'\t'<<orien[i]<<'\t'<<"-"<<'\t'<<l_len<<'\t'<<r_len<<'\t'<<trans_len<<'\t'<<loc_TP[i][0]<<'\t'<<int((L1_s_TP1+L1_s_TP2)/2)<<'\t'<<int((L1_e_TP1+L1_e_TP2)/2)<<endl;
                         
                     }
                     else {
-                        file2<<"cluster"<<i<<"_"<<info[i][1]<<"_"<<start1+S<<"_"<<start2-S<<"_"<<end1+S<<"_"<<end2-S<<'\t'<<info[i][1]<<'\t'<<start1+S<<'\t'<<start2-S<<'\t'<<end1+S<<'\t'<<end2-S<<'\t'<<L1_s1+L<<'\t'<<L1_s2-L<<'\t'<<L1_e1+L<<'\t'<<L1_e2-L<<'\t'<<p<<'\t'<<number_all<<'\t'<<(number_all-number)<<'\t'<<orien[i]<<'\t'<<pa_len<<'\t'<<l_len<<'\t'<<r_len<<'\t'<<trans_len<<'\t'<<loc_TP[i][0]<<'\t'<<int((L1_s_TP1+L1_s_TP2)/2)<<'\t'<<int((L1_e_TP1+L1_e_TP2)/2)<<endl;
+                        file2<<"cluster"<<i<<"_"<<info[i][1]<<"_"<<start1+S<<"_"<<start2-S<<"_"<<end1+S<<"_"<<end2-S<<'\t'<<info[i][1]<<'\t'<<start1+S<<'\t'<<start2-S<<'\t'<<end1+S<<'\t'<<end2-S<<'\t'<<L1_s1+L<<'\t'<<L1_s2-L<<'\t'<<L1_e1+L<<'\t'<<L1_e2-L<<'\t'<<p<<'\t'<<supporting_reads_from_5_end<<'\t'<<supporting_reads_from_3_end<<'\t'<<total_potential_supporting_reads<<'\t'<<(number_all-number)<<'\t'<<orien[i]<<'\t'<<pa_len<<'\t'<<l_len<<'\t'<<r_len<<'\t'<<trans_len<<'\t'<<loc_TP[i][0]<<'\t'<<int((L1_s_TP1+L1_s_TP2)/2)<<'\t'<<int((L1_e_TP1+L1_e_TP2)/2)<<endl;
                     }
                     
                     //return
@@ -1888,7 +1904,7 @@ int calling(string WD_dir, string t, int tsd_index){
             }
             }
             else if (tsd_index==0){
-                file2<<"cluster"<<i<<"_"<<info[i][1]<<"_"<<start1+S<<"_"<<start2-S<<"_"<<end1+S<<"_"<<end2-S<<'\t'<<info[i][1]<<'\t'<<start1+S<<'\t'<<start2-S<<'\t'<<end1+S<<'\t'<<end2-S<<'\t'<<L1_s1+L<<'\t'<<L1_s2-L<<'\t'<<L1_e1+L<<'\t'<<L1_e2-L<<'\t'<<"0"<<'\t'<<number_all<<'\t'<<(number_all-number)<<'\t'<<orien[i]<<'\t'<<"-"<<'\t'<<"0"<<'\t'<<"0"<<'\t'<<"0"<<'\t'<<loc_TP[i][0]<<'\t'<<int((L1_s_TP1+L1_s_TP2)/2)<<'\t'<<int((L1_e_TP1+L1_e_TP2)/2)<<endl;
+                file2<<"cluster"<<i<<"_"<<info[i][1]<<"_"<<start1+S<<"_"<<start2-S<<"_"<<end1+S<<"_"<<end2-S<<'\t'<<info[i][1]<<'\t'<<start1+S<<'\t'<<start2-S<<'\t'<<end1+S<<'\t'<<end2-S<<'\t'<<L1_s1+L<<'\t'<<L1_s2-L<<'\t'<<L1_e1+L<<'\t'<<L1_e2-L<<'\t'<<"0"<<'\t'<<supporting_reads_from_5_end<<'\t'<<supporting_reads_from_3_end<<'\t'<<total_potential_supporting_reads<<'\t'<<(number_all-number)<<'\t'<<orien[i]<<'\t'<<"-"<<'\t'<<"0"<<'\t'<<"0"<<'\t'<<"0"<<'\t'<<loc_TP[i][0]<<'\t'<<int((L1_s_TP1+L1_s_TP2)/2)<<'\t'<<int((L1_e_TP1+L1_e_TP2)/2)<<endl;
                 file4<<"cluster"<<i<<"_"<<info[i][1]<<"_"<<start1+S<<"_"<<start2-S<<"_"<<end1+S<<"_"<<end2-S<<'\t'<<seq_index_a<<'\t'<<"N"<<'\t'<<"N"<<'\t'<<"N"<<'\t'<<"N"<<'\t'<<info_line[i][2]<<endl;
             }
                 


### PR DESCRIPTION
## Summary
- add a total potential supporting reads column alongside the per-end counts in merged call outputs and VCF INFO
- propagate the orientation-aware per-end counts and the combined total through PALMER calling and clustering
- update the sample calls header to reflect the new total potential support field

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930b901823c83328e6e582e4ebc1146)